### PR TITLE
Compatibility CentOS

### DIFF
--- a/svc_mon
+++ b/svc_mon
@@ -10,12 +10,12 @@
 # 
 set -e
 
-. /etc/zabbix/externalscripts/svc_perf.conf
+. $ZABBIX_SCRIPTS/svc_perf.conf
 
 ERR_LOG=/var/cache/zabbix/svc_mon.errlog
 
 echo >>"$ERR_LOG"
 date >>"$ERR_LOG"
-/usr/bin/python /etc/zabbix/externalscripts/svc_mon.py "$DEBUG" --clusters "$1" --user "$SVC_USER" --password "$SVC_PWD" 2>>"$ERR_LOG" | zabbix_sender -z 127.0.0.1 -I 127.0.0.1 -T -i - >>"$ERR_LOG" 2>&1
+/usr/bin/python $ZABBIX_SCRIPTS/svc_mon.py "$DEBUG" --clusters "$1" --user "$SVC_USER" --password "$SVC_PWD" 2>>"$ERR_LOG" | zabbix_sender -z 127.0.0.1 -I 127.0.0.1 -T -i - >>"$ERR_LOG" 2>&1
 date >>"$ERR_LOG"
 

--- a/svc_mon2
+++ b/svc_mon2
@@ -2,7 +2,7 @@
 #
 # svc_mon2 <svc_dns_name> <svc_host> [<--unified>]
 #
-. /etc/zabbix/externalscripts/svc_perf.conf
+. $ZABBIX_SCRIPTS/svc_perf.conf
 
 ERR_LOG=/var/log/zabbix/svc_mon2.log
 
@@ -10,7 +10,7 @@ DEBUG=--debug
 
 echo >>"$ERR_LOG"
 echo "$1" "$2" "$3" $(date) >>"$ERR_LOG"
-/usr/bin/python /etc/zabbix/externalscripts/svc_mon2.py "$DEBUG" --svc "$1" "$3" --user "$SVC_USER" --password "$SVC_PWD" --host "$2" >>"$ERR_LOG" 2>&1
+/usr/bin/python $ZABBIX_SCRIPTS/svc_mon2.py "$DEBUG" --svc "$1" "$3" --user "$SVC_USER" --password "$SVC_PWD" --host "$2" >>"$ERR_LOG" 2>&1
 STATUS="$?"
 echo "$1" "$2" "$3" $(date) >>"$ERR_LOG"
 echo "$STATUS"

--- a/svc_perf
+++ b/svc_perf
@@ -16,7 +16,7 @@
 # 
 set -e
 
-. /etc/zabbix/externalscripts/svc_perf.conf
+. $ZABBIX_SCRIPTS/svc_perf.conf
 
 CLUSTER=$1
 
@@ -25,6 +25,6 @@ ERR_LOG=/var/cache/zabbix/svc_perf.$CLUSTER.errlog
 
 echo >>"$ERR_LOG"
 date >>"$ERR_LOG"
-/usr/bin/python /etc/zabbix/externalscripts/svc_perf_wbem.py --cluster $CLUSTER --user "$SVC_USER" --password "$SVC_PWD" --cachefile "$CACHE_FILE" 2>>"$ERR_LOG" | zabbix_sender -z 127.0.0.1 -I 127.0.0.1 -T -i - >>"$ERR_LOG" 2>&1
+/usr/bin/python $ZABBIX_SCRIPTS/svc_perf_wbem.py --cluster $CLUSTER --user "$SVC_USER" --password "$SVC_PWD" --cachefile "$CACHE_FILE" 2>>"$ERR_LOG" | zabbix_sender -z 127.0.0.1 -I 127.0.0.1 -T -i - >>"$ERR_LOG" 2>&1
 date >>"$ERR_LOG"
 

--- a/svc_perf.conf
+++ b/svc_perf.conf
@@ -12,3 +12,6 @@ ZABBIX_PASSWORD=**********
 
 ### Uncomment to get debug output in logs
 #DEBUG=--debug
+
+# Folder externalscript
+ZABBIX_SCRIPTS=/usr/lib/zabbix/externalscripts

--- a/svc_perf_cron
+++ b/svc_perf_cron
@@ -1,3 +1,4 @@
+### Replace /etc/zabbix/externalscripts to /var/lib/zabbix/externalscripts in CentOS
 # Get Storwize perf stats. Interval specified here must match Storwize stats refresh interval ("startstats -interval")
 1-59/3 * * * * root /etc/zabbix/externalscripts/svc_perf svc1-blk > /dev/null 2>&1 || :
 2-59/3 * * * * root /etc/zabbix/externalscripts/svc_perf dev-svc1 > /dev/null 2>&1 || :

--- a/svc_perf_discovery_sender
+++ b/svc_perf_discovery_sender
@@ -16,10 +16,10 @@
 
 set -e
 
-. /etc/zabbix/externalscripts/svc_perf.conf
+. $ZABBIX_SCRIPTS/svc_perf.conf
 
 ERR_LOG=/var/cache/zabbix/svc_perf_discovery_sender
 
 echo start `date` $1 $2 >> "$ERR_LOG"
-/usr/bin/python /etc/zabbix/externalscripts/svc_perf_discovery_sender.py "$DEBUG" --clusters "$1" --user "$SVC_USER" --password "$SVC_PWD" >>"$ERR_LOG" 2>&1
+/usr/bin/python $ZABBIX_SCRIPTS/svc_perf_discovery_sender.py "$DEBUG" --clusters "$1" --user "$SVC_USER" --password "$SVC_PWD" >>"$ERR_LOG" 2>&1
 echo end `date` $1 $2 >> "$ERR_LOG"

--- a/svc_perf_graph
+++ b/svc_perf_graph
@@ -22,13 +22,13 @@
 
 set -e
 
-. /etc/zabbix/externalscripts/svc_perf.conf
+. $ZABBIX_SCRIPTS/svc_perf.conf
 
 ERR_LOG=/var/cache/zabbix/svc_perf_graph.log
 
 echo >>"$ERR_LOG"
 date >>"$ERR_LOG"
-/usr/bin/python /etc/zabbix/externalscripts/svc_perf_graph.py "$DEBUG" --clusters "$1" --user "$SVC_USER" --password "$SVC_PWD" --zabbix_url "$ZABBIX_SERVER" --zabbix_user "$ZABBIX_USER" --zabbix_password "$ZABBIX_PASSWORD" >>"$ERR_LOG" 2>&1
+/usr/bin/python $ZABBIX_SCRIPTS/svc_perf_graph.py "$DEBUG" --clusters "$1" --user "$SVC_USER" --password "$SVC_PWD" --zabbix_url "$ZABBIX_SERVER" --zabbix_user "$ZABBIX_USER" --zabbix_password "$ZABBIX_PASSWORD" >>"$ERR_LOG" 2>&1
 date >>"$ERR_LOG"
  
 

--- a/svc_status.sh
+++ b/svc_status.sh
@@ -17,7 +17,7 @@
 #
 # Key-based SSH access to Storwize CLI needs to be configured for zabbix user (see /var/lib/zabbix/.ssh)
 #
-SVC_STATUS_AWK=/etc/zabbix/externalscripts/svc_status.awk
+SVC_STATUS_AWK=$ZABBIX_SCRIPTS/svc_status.awk
 
 # run lseventlog command with ssh
 EVENTS=$(ssh -q -o PasswordAuthentication=no $1 lseventlog -expired no -fixed no -monitoring no -message no -order severity)


### PR DESCRIPTION
Use variable $ZABBIX_SCRIPTS to redirect to externalscripts folder

In CentOS, externalscripts folder is /usr/lib/zabbix/externalscripts
